### PR TITLE
fix: use legacy container in migration

### DIFF
--- a/migrations/Version202112151309292752_taoEventLog.php
+++ b/migrations/Version202112151309292752_taoEventLog.php
@@ -46,25 +46,29 @@ final class Version202112151309292752_taoEventLog extends AbstractMigration
 
     public function up(Schema $schema): void
     {
+        $serviceLocator = $this->getServiceLocator();
+
         /** @var EventManager $eventManager */
-        $eventManager = $this->getServiceLocator()->getContainer()->get(EventManager::SERVICE_ID);
+        $eventManager = $serviceLocator->get(EventManager::SERVICE_ID);
 
         foreach (self::EVENTS as $event) {
             $eventManager->attach($event, [LoggerService::class, 'logEvent']);
         }
 
-        $this->getServiceLocator()->register(EventManager::SERVICE_ID, $eventManager);
+        $serviceLocator->register(EventManager::SERVICE_ID, $eventManager);
     }
 
     public function down(Schema $schema): void
     {
+        $serviceLocator = $this->getServiceLocator();
+
         /** @var EventManager $eventManager */
-        $eventManager = $this->getServiceLocator()->getContainer()->get(EventManager::SERVICE_ID);
+        $eventManager = $serviceLocator->get(EventManager::SERVICE_ID);
 
         foreach (self::EVENTS as $event) {
             $eventManager->detach($event, [LoggerService::class, 'logEvent']);
         }
 
-        $this->getServiceLocator()->register(EventManager::SERVICE_ID, $eventManager);
+        $serviceLocator->register(EventManager::SERVICE_ID, $eventManager);
     }
 }


### PR DESCRIPTION
For backward compatibility with older releases, the use of the DI container in the migration script has been replaced with a legacy container.