### PR TITLE
PHP 8 migration

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -16,7 +16,7 @@ jobs:
         operating-system: [ ubuntu-latest ]
         php-version: [ '7.4', '8.0', '8.1' ]
         include:
-          - php-version: '7.4'
+          - php-version: '8.1'
             coverage: true
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "oat-sa/extension-tao-itemqti" : ">=27.0.0",
     "oat-sa/extension-tao-test" : ">=15.11.0",
     "oat-sa/extension-tao-testtaker" : ">=8.0.0",
-    "oat-sa/lib-tao-dtms" : "dev-php8-migration as v2.0.0"
+    "oat-sa/lib-tao-dtms" : "1.0.0"
   },
   "autoload": {
     "psr-4": {
@@ -40,6 +40,8 @@
   "require-dev": {
     "oat-sa/generis": "dev-php8-migration as v16.0.0",
     "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
-    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0"
+    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
+    "oat-sa/extension-tao-itemqti" : "dev-dev-php8-migration as v30.0.0",
+    "oat-sa/lib-tao-dtms" : "dev-php8-migration as v1.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
   "require-dev": {
     "oat-sa/generis": "dev-php8-migration as v16.0.0",
     "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
-    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0"
+    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
+    "oat-sa/lib-tao-dtms" : "dev-php8-migration as v2.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "oat-sa/extension-tao-itemqti" : ">=27.0.0",
     "oat-sa/extension-tao-test" : ">=15.11.0",
     "oat-sa/extension-tao-testtaker" : ">=8.0.0",
-    "oat-sa/lib-tao-dtms" : "1.0.0"
+    "oat-sa/lib-tao-dtms" : "dev-php8-migration as v2.0.0"
   },
   "autoload": {
     "psr-4": {
@@ -40,7 +40,6 @@
   "require-dev": {
     "oat-sa/generis": "dev-php8-migration as v16.0.0",
     "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
-    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
-    "oat-sa/lib-tao-dtms" : "dev-php8-migration as v2.0.0"
+    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,10 @@
     "psr-4": {
       "oat\\taoEventLog\\": ""
     }
+  },
+  "require-dev": {
+    "oat-sa/generis": "dev-php8-migration as v16.0.0",
+    "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
+    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,8 +21,8 @@
   "minimum-stability": "dev",
   "require": {
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master",
-    "oat-sa/generis" : ">=15.13.0",
-    "oat-sa/tao-core" : ">=48.70.0",
+    "oat-sa/generis" : ">=15.22",
+    "oat-sa/tao-core" : ">=50.24.6",
     "oat-sa/extension-tao-funcacl" : ">=7.0.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
     "oat-sa/extension-tao-item" : ">=11.0.0",
@@ -36,11 +36,5 @@
     "psr-4": {
       "oat\\taoEventLog\\": ""
     }
-  },
-  "require-dev": {
-    "oat-sa/generis": "dev-php8-migration as v16.0.0",
-    "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
-    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
-    "oat-sa/extension-tao-outcome": "dev-php8-migration as v14.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "oat-sa/extension-tao-itemqti" : ">=27.0.0",
     "oat-sa/extension-tao-test" : ">=15.11.0",
     "oat-sa/extension-tao-testtaker" : ">=8.0.0",
-    "oat-sa/lib-tao-dtms" : "1.0.0"
+    "oat-sa/lib-tao-dtms" : "dev-php8-migration as 1.0.1"
   },
   "autoload": {
     "psr-4": {
@@ -40,8 +40,6 @@
   "require-dev": {
     "oat-sa/generis": "dev-php8-migration as v16.0.0",
     "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
-    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
-    "oat-sa/extension-tao-itemqti" : "dev-php8-migration as v30.0.0",
-    "oat-sa/lib-tao-dtms" : "dev-php8-migration as v1.0.0"
+    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "oat-sa/extension-tao-itemqti" : ">=27.0.0",
     "oat-sa/extension-tao-test" : ">=15.11.0",
     "oat-sa/extension-tao-testtaker" : ">=8.0.0",
-    "oat-sa/lib-tao-dtms" : "dev-php8-migration as 1.0.1"
+    "oat-sa/lib-tao-dtms" : "^1.0.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,6 @@
     "oat-sa/generis": "dev-php8-migration as v16.0.0",
     "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
     "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
-    "oat-sa/extension-lti-outcome": "dev-php8-migration as v14.0.0"
+    "oat-sa/extension-tao-outcome": "dev-php8-migration as v14.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
   "require-dev": {
     "oat-sa/generis": "dev-php8-migration as v16.0.0",
     "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
-    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0"
+    "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
+    "oat-sa/extension-lti-outcome": "dev-php8-migration as v14.0.0"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "oat-sa/generis": "dev-php8-migration as v16.0.0",
     "oat-sa/tao-core": "dev-php8-migration as v51.0.0",
     "oat-sa/extension-tao-testqti": "dev-php8-migration as v45.0.0",
-    "oat-sa/extension-tao-itemqti" : "dev-dev-php8-migration as v30.0.0",
+    "oat-sa/extension-tao-itemqti" : "dev-php8-migration as v30.0.0",
     "oat-sa/lib-tao-dtms" : "dev-php8-migration as v1.0.0"
   }
 }


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/ADF-1097
https://oat-sa.atlassian.net/browse/ADF-1087
https://oat-sa.atlassian.net/browse/ADF-1105

## Goal 

Make the extension not dictating PHP version to easier our PHP maintenance, since the extension does not work in isolation and PHP version should be equally respected to all TAO extensions.