### PR TITLE
SOLAR-1191: expand the roles field to handle a bigger roles list as it tends to grow.

### DIFF
--- a/migrations/Version202412181339442234_taoEventLog.php
+++ b/migrations/Version202412181339442234_taoEventLog.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2024 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoEventLog\migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
+use oat\generis\persistence\PersistenceManager;
+use oat\oatbox\reporting\Report;
+use oat\tao\scripts\tools\migrations\AbstractMigration;
+use oat\taoEventLog\model\userLastActivityLog\rds\UserLastActivityLogStorage;
+
+final class Version202412181339442234_taoEventLog extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return sprintf(
+            'Expand role field for "%s" table',
+            UserLastActivityLogStorage::TABLE_NAME
+        );
+    }
+
+    public function up(Schema $schema): void
+    {
+        $originalSchema = clone $schema;
+        $this->updateTable($schema, Type::getType(Types::TEXT));
+        $this->migrate($originalSchema, $schema);
+
+        $this->addReport(
+            Report::createSuccess(
+                sprintf(
+                    'Table "%s" successfully updated',
+                    UserLastActivityLogStorage::TABLE_NAME
+                )
+            )
+        );
+    }
+
+    public function down(Schema $schema): void
+    {
+        $originalSchema = clone $schema;
+        $this->updateTable($schema, Type::getType(Types::STRING));
+        $this->migrate($originalSchema, $schema);
+
+        $this->addReport(
+            Report::createSuccess(
+                sprintf(
+                    'Table "%s" successfully reverted',
+                    UserLastActivityLogStorage::TABLE_NAME
+                )
+            )
+        );
+    }
+
+    private function updateTable(Schema $schema, Type $filedType): void
+    {
+        $userLastActivityLogTable = $schema->getTable(
+            UserLastActivityLogStorage::TABLE_NAME
+        );
+
+        $userLastActivityLogTable->changeColumn(
+            UserLastActivityLogStorage::COLUMN_USER_ROLES,
+            [
+                'type' => $filedType,
+            ]
+        );
+    }
+
+    private function migrate(Schema $originalSchema, Schema $schema): void
+    {
+        $persistenceManager = $this->getServiceLocator()->get(PersistenceManager::SERVICE_ID);
+        $persistence = $persistenceManager->getPersistenceById('default');
+
+        $queries = $persistence->getPlatForm()->getMigrateSchemaSql($originalSchema, $schema);
+        foreach ($queries as $query) {
+            $persistence->exec($query);
+        }
+    }
+}

--- a/model/userLastActivityLog/rds/UserLastActivityLogStorage.php
+++ b/model/userLastActivityLog/rds/UserLastActivityLogStorage.php
@@ -208,7 +208,7 @@ class UserLastActivityLogStorage extends ConfigurableService implements UserLast
             $table = $schema->createTable(self::TABLE_NAME);
             $table->addOption('engine', 'InnoDB');
             $table->addColumn(static::COLUMN_USER_ID, "string", ["length" => 255]);
-            $table->addColumn(static::COLUMN_USER_ROLES, "string", ["notnull" => true, "length" => 4096]);
+            $table->addColumn(static::COLUMN_USER_ROLES, "text", ["notnull" => true]);
             $table->addColumn(static::COLUMN_ACTION, "string", ["notnull" => false, "length" => 4096]);
             $table->addColumn(
                 static::COLUMN_EVENT_TIME,


### PR DESCRIPTION
## Goal
Fix the problem with LTI role length as they tend to grow, and the current role field is not enough to store the activity.

## Changelog
- fix: expand the roles field to handle a bigger roles list as it tends to grow.

## How to test/use
1. Make sure the LTI role has more than 67 unique roles included
2. log in portal
3. click on a content bank (do LTI login)

