### PR TITLE
fix: persist atomic user roles, catch exceptions

### DIFF
--- a/model/userLastActivityLog/rds/UserLastActivityLogStorage.php
+++ b/model/userLastActivityLog/rds/UserLastActivityLogStorage.php
@@ -25,6 +25,8 @@ use common_persistence_Persistence;
 use common_persistence_SqlPersistence;
 use common_report_Report;
 use common_session_SessionManager;
+use oat\generis\model\GenerisRdf;
+use oat\oatbox\log\LoggerAwareTrait;
 use oat\oatbox\user\User;
 use oat\taoEventLog\model\RdsLogIterator;
 use oat\taoEventLog\model\userLastActivityLog\UserLastActivityLog;
@@ -41,6 +43,8 @@ use GuzzleHttp\Psr7\ServerRequest;
  */
 class UserLastActivityLogStorage extends ConfigurableService implements UserLastActivityLog
 {
+    use LoggerAwareTrait;
+
     public const OPTION_PERSISTENCE = 'persistence_id';
     public const TABLE_NAME = 'user_last_activity_log';
 
@@ -65,17 +69,30 @@ class UserLastActivityLogStorage extends ConfigurableService implements UserLast
             $userId = get_class($user);
         }
 
+        $roles = array_unique($user->getPropertyValues(GenerisRdf::PROPERTY_USER_ROLES));
+        sort($roles);
+
         $data = [
             self::USER_ID => $userId,
-            self::USER_ROLES => ',' . implode(',', $user->getRoles()) . ',',
+            self::USER_ROLES => ',' . implode(',', $roles) . ',',
             self::COLUMN_ACTION => strval($action),
             self::COLUMN_EVENT_TIME => microtime(true),
             self::COLUMN_DETAILS => json_encode($details),
         ];
-        $this->getPersistence()->exec(
-            'DELETE FROM ' . self::TABLE_NAME . ' WHERE ' . self::USER_ID . ' = \'' . $userId . '\''
-        );
-        $this->getPersistence()->insert(self::TABLE_NAME, $data);
+
+        try {
+            $this->getPersistence()->exec(
+                'DELETE FROM ' . self::TABLE_NAME . ' WHERE ' . self::USER_ID . ' = ?',
+                [$userId]
+            );
+            $this->getPersistence()->insert(self::TABLE_NAME, $data);
+        } catch (\Throwable $e) {
+            $this->logWarning(sprintf(
+                '[taoEventLog] Failed to log user activity for %s: %s',
+                $userId,
+                $e->getMessage()
+            ));
+        }
     }
 
     /**

--- a/test/model/userLastActivityLog/rds/UserActivityLogStorageTest.php
+++ b/test/model/userLastActivityLog/rds/UserActivityLogStorageTest.php
@@ -20,6 +20,7 @@
 
 namespace oat\taoEventLog\test\model\userLastActivityLog\rds;
 
+use oat\generis\model\GenerisRdf;
 use oat\generis\test\SqlMockTrait;
 use oat\tao\test\TaoPhpUnitTestRunner;
 use oat\taoEventLog\model\userLastActivityLog\rds\UserLastActivityLogStorage as Storage;
@@ -39,9 +40,19 @@ class UserActivityLogStorageTest extends TestCase
 
     public function testLog()
     {
-        $user = new TestUser([
-            'admin', 'proctor',
-        ], 'http://sample/first.rdf#i00000000000000001_test_record');
+        $leafRoles = ['proctor', 'admin', 'admin'];
+        $expandedRoles = [
+            'admin',
+            'proctor',
+            'http://www.tao.lu/Ontologies/generis.rdf#BaseRole',
+            'http://www.tao.lu/Ontologies/TAO.rdf#TaoManagerRole',
+            'http://www.tao.lu/Ontologies/TAOItem.rdf#ItemAuthor',
+        ];
+        $user = new TestUser(
+            $leafRoles,
+            $expandedRoles,
+            'http://sample/first.rdf#i00000000000000001_test_record'
+        );
         $details = ['testKey' => 'testVal'];
         $service = $this->getService();
         $service->log($user, 'testAction', $details);
@@ -51,7 +62,7 @@ class UserActivityLogStorageTest extends TestCase
         );
         $data = $stmt->fetchAssociative();
         $this->assertEquals($user->getIdentifier(), $data[Storage::COLUMN_USER_ID]);
-        $this->assertEquals(',' . implode(',', $user->getRoles()) . ',', $data[Storage::COLUMN_USER_ROLES]);
+        $this->assertEquals(',admin,proctor,', $data[Storage::COLUMN_USER_ROLES]);
         $this->assertEquals('testAction', $data[Storage::COLUMN_ACTION]);
         $this->assertEquals(json_encode($details), $data[Storage::COLUMN_DETAILS]);
 
@@ -64,6 +75,43 @@ class UserActivityLogStorageTest extends TestCase
         );
         $data = $stmt->fetchAllAssociative();
         $this->assertEquals(1, count($data));
+    }
+
+    public function testLogPersistsRowForUserIdContainingQuote()
+    {
+        $userId = "http://sample/first.rdf#O'Brien_test_record";
+        $user = new TestUser(['admin'], ['admin'], $userId);
+
+        $service = $this->getService();
+        $service->log($user, 'testAction', ['k' => 'v']);
+
+        $count = $service->count([
+            [Storage::COLUMN_USER_ID, '=', $userId],
+        ]);
+        $this->assertEquals(1, $count);
+    }
+
+    public function testLogSwallowsPersistenceFailure()
+    {
+        $throwingPersistence = new ThrowingPersistence();
+        $persistenceManager = new ThrowingPersistenceManager($throwingPersistence);
+
+        $config = new \common_persistence_KeyValuePersistence(new \common_persistence_InMemoryKvDriver(), []);
+        $config->set(\common_persistence_Manager::SERVICE_ID, $persistenceManager);
+        $serviceManager = new ServiceManager($config);
+
+        $service = new Storage([Storage::OPTION_PERSISTENCE => 'throwing']);
+        $service->setServiceManager($serviceManager);
+        $service->setLogger(new \Psr\Log\NullLogger());
+
+        $user = new TestUser(
+            ['admin'],
+            ['admin'],
+            'http://sample/first.rdf#i00000000000000099_test_record'
+        );
+
+        $service->log($user, 'testAction', ['k' => 'v']);
+        $this->addToAssertionCount(1);
     }
 
     public function testFind()
@@ -230,6 +278,7 @@ class UserActivityLogStorageTest extends TestCase
             $config->set(\common_persistence_Manager::SERVICE_ID, $persistenceManager);
             $serviceManager = new ServiceManager($config);
             $this->service->setServiceManager($serviceManager);
+            $this->service->setLogger(new \Psr\Log\NullLogger());
             $this->loadFixtures($this->persistence);
         }
         return $this->service;
@@ -238,13 +287,14 @@ class UserActivityLogStorageTest extends TestCase
 
 class TestUser extends \common_test_TestUser
 {
-    protected $roles;
+    protected $expandedRoles;
     protected $id;
 
-    public function __construct(array $roles, $id)
+    public function __construct(array $leafRoles, array $expandedRoles, $id)
     {
-        $this->roles = $roles;
+        $this->expandedRoles = $expandedRoles;
         $this->id = $id;
+        $this->setPropertyValues(GenerisRdf::PROPERTY_USER_ROLES, $leafRoles);
     }
 
     public function getIdentifier()
@@ -254,6 +304,34 @@ class TestUser extends \common_test_TestUser
 
     public function getRoles()
     {
-        return $this->roles;
+        return $this->expandedRoles;
+    }
+}
+
+class ThrowingPersistence
+{
+    public function exec($sql, $params = [])
+    {
+        throw new \RuntimeException('delete failed');
+    }
+
+    public function insert($table, $data)
+    {
+        throw new \RuntimeException('insert failed');
+    }
+}
+
+class ThrowingPersistenceManager
+{
+    private $persistence;
+
+    public function __construct($persistence)
+    {
+        $this->persistence = $persistence;
+    }
+
+    public function getPersistenceById($id)
+    {
+        return $this->persistence;
     }
 }


### PR DESCRIPTION
## Tasks
https://oat-sa.atlassian.net/browse/INF-506

## Changelog
- Persist atomic user roles
- Catch audit failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user activity logging to gracefully handle and recover from persistence failures without disrupting operations
  * Enhanced user roles data consistency through deduplication and standardized sorting

* **Tests**
  * Expanded test coverage to verify handling of special characters in user identifiers
  * Added tests validating resilience when persistence operations fail

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/extension-tao-eventlog/pull/171)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->